### PR TITLE
refactor: legacy php

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,8 @@ jobs:
           sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
           sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
           sed -i '/stretch-updates/d' /etc/apt/sources.list
-          apt-get update -qq && apt-get install -y -qq git
+          apt-get -o Acquire::Check-Valid-Until=false -o Acquire::AllowInsecureRepositories=true update -qq
+          apt-get install -y -qq --allow-unauthenticated git
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,8 @@ name: Check PHP
 
 on:
   push:
+    branches:
+      - master
     paths:
       - "**/*.php"
       - ".github/workflows/*.yml"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -44,7 +44,11 @@ jobs:
 
     steps:
       - name: Install git
-        run: apt-get update -qq && apt-get install -y -qq git
+        run: |
+          sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
+          sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
+          sed -i '/stretch-updates/d' /etc/apt/sources.list
+          apt-get update -qq && apt-get install -y -qq git
 
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,14 +1,14 @@
 name: Check PHP
 
 on:
-    push:
-      paths:
-        - '**/*.php'
-        - '.github/workflows/*.yml'
-    pull_request:
-      paths:
-        - '**/*.php'
-        - '.github/workflows/*.yml'
+  push:
+    paths:
+      - "**/*.php"
+      - ".github/workflows/*.yml"
+  pull_request:
+    paths:
+      - "**/*.php"
+      - ".github/workflows/*.yml"
 
 jobs:
   lint:
@@ -22,12 +22,12 @@ jobs:
       - name: Set up PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: '8.1'
+          php-version: "8.1"
 
       - name: Run PHP lint
         run: |
           find . -name "*.php" -print0 | xargs -0 -n1 php -l
-    
+
       - name: Install PHPStan
         run: |
           composer global require phpstan/phpstan
@@ -36,3 +36,18 @@ jobs:
         run: |
           phpstan analyse --level=5 --no-progress .
 
+  legacy-compat:
+    name: Legacy PHP compatibility
+    runs-on: ubuntu-latest
+    container:
+      image: php:5.6-cli
+
+    steps:
+      - name: Install git
+        run: apt-get update -qq && apt-get install -y -qq git
+
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Run PHP 5.6 lint
+        run: find . -name "*.php" -print0 | xargs -0 -n1 php -l

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,20 +39,15 @@ jobs:
   legacy-compat:
     name: Legacy PHP compatibility
     runs-on: ubuntu-latest
-    container:
-      image: php:5.6-cli
 
     steps:
-      - name: Install git
-        run: |
-          sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g' /etc/apt/sources.list
-          sed -i 's|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
-          sed -i '/stretch-updates/d' /etc/apt/sources.list
-          apt-get -o Acquire::Check-Valid-Until=false -o Acquire::AllowInsecureRepositories=true update -qq
-          apt-get install -y -qq --allow-unauthenticated git
-
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
-      - name: Run PHP 5.6 lint
-        run: find . -name "*.php" -print0 | xargs -0 -n1 php -l
+      - name: Run PHP 5.6 lint in container
+        run: |
+          docker run --rm \
+            -v "${{ github.workspace }}:/workspace" \
+            -w /workspace \
+            php:5.6-cli \
+            sh -c 'find . -name "*.php" -print0 | xargs -0 -n1 php -l'

--- a/scan.php
+++ b/scan.php
@@ -17,7 +17,7 @@ $flagFromScore = SCORE_MEDIUM; // Minimum score to count as "flagged" in the sum
 $maxFileSize   = 1 * 1024 * 1024; // Maximum file size to scan in bytes. Override with --max.
 
 // Config
-$defaultDir = getcwd() ?: '.';
+$defaultDir = getcwd() ? getcwd() : '.';
 $defaultLog = getcwd() . DIRECTORY_SEPARATOR . 'suspicious_' . date('Ymd') . '.log';
 
 // Get $1 and $2 args
@@ -196,7 +196,7 @@ $filesSkipped       = 0;
 $riskCounts         = array('critical' => 0, 'high' => 0, 'medium' => 0, 'low' => 0, 'clean' => 0);
 
 // Check if is excluded
-function isExcluded(string $dir): bool {
+function isExcluded($dir) {
     global $excludedDirs;
     /** @var string[] $excludedDirs */
     foreach ($excludedDirs as $excludedDir) {
@@ -208,7 +208,7 @@ function isExcluded(string $dir): bool {
 }
 
 // Perms for dirs
-function checkPerms(string $dir): void {
+function checkPerms($dir) {
     if (!is_readable($dir)) {
         throw new Exception("Error: unable to read directory: $dir");
     }
@@ -230,7 +230,7 @@ function checkPerms(string $dir): void {
 /**
  * @return array{label: string, color: string, key: string}
  */
-function getRiskLevel(int $score): array {
+function getRiskLevel($score) {
     if ($score >= SCORE_CRITICAL) return array('label' => 'CRITICAL', 'color' => "\033[35m", 'key' => 'critical'); // Magenta
     if ($score >= SCORE_HIGH)     return array('label' => 'HIGH',     'color' => "\033[31m", 'key' => 'high');     // Red
     if ($score >= SCORE_MEDIUM)   return array('label' => 'MEDIUM',   'color' => "\033[33m", 'key' => 'medium');   // Yellow
@@ -240,7 +240,7 @@ function getRiskLevel(int $score): array {
 
 // Scan file — accumulates scores for all matched patterns, returns total score.
 // Returns -1 if the file cannot be read.
-function scanFile(string $filePath): int {
+function scanFile($filePath) {
     global $suspiciousPatterns, $targetLog, $minRiskScore;
     /** @var array<int, array{pattern: string, score: int, desc: string}> $suspiciousPatterns */
     /** @var string $targetLog */
@@ -285,14 +285,14 @@ function scanFile(string $filePath): int {
 }
 
 // Write logs
-function logMessage(string $message): void {
+function logMessage($message) {
     global $targetLog;
     /** @var string $targetLog */
     $logEntry = date('Y-m-d H:i:s') . ' - ' . $message . PHP_EOL;
     file_put_contents($targetLog, $logEntry, FILE_APPEND);
 }
 
-function scanDirectory(string $dir): bool {
+function scanDirectory($dir) {
     global $targetLog, $totalFilesScanned, $filesSkipped, $maxFileSize, $riskCounts, $flagFromScore;
     /** @var string $targetLog */
     /** @var int $totalFilesScanned */


### PR DESCRIPTION
Since this was designed to work on old systems, this PR removes some syntax that would be incompatible with PHP5: 

Scalar type hints taken out, and now returning type declarations. Removed operators from newer PHP. Added a new CI runner to do a dry run in PHP5.